### PR TITLE
option to terminate by time or number of requests

### DIFF
--- a/SocketPerfTest/Program.cs
+++ b/SocketPerfTest/Program.cs
@@ -1,6 +1,7 @@
 ﻿using CommandLine;
 using System;
 using System.Threading;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
@@ -119,41 +120,45 @@ namespace SslStreamPerf
                 countAfterWarmup = GetCurrentRequestCount(clientHandlers);
             }
 
-            int elapsed = 0;
+            Stopwatch timer = new Stopwatch();
+            long elapsed = 0;   // time in milliseconds
+            long previousElapsed = 0;
             int previousCount = countAfterWarmup;
-            int ReportingInterval = options.ReportingInterval > 0 ? options.ReportingInterval : 1;
+            int reportingInterval = options.ReportingInterval > 0 ? options.ReportingInterval :
+                                        options.DurationTime > 0 ? options.DurationTime : 1;
             double currentRPS;
             double averageRPS;
 
+            timer.Start();
             while (true)
             {
-                Thread.Sleep(ReportingInterval * 1000);
+                Thread.Sleep(reportingInterval * 1000);
 
-                elapsed += ReportingInterval;
+                elapsed = timer.ElapsedMilliseconds;
+
                 int currentCount = GetCurrentRequestCount(clientHandlers);
 
-                currentRPS = (currentCount - previousCount) / (double)options.ReportingInterval;
-                averageRPS = (currentCount - countAfterWarmup) / (double)elapsed;
+                currentRPS = (currentCount - previousCount) / ((elapsed - previousElapsed)/1000);
+                averageRPS = (currentCount - countAfterWarmup) / ((double)elapsed/1000);
 
                 if (options.ReportingInterval > 0)
                 {
-                    Console.WriteLine($"Elapsed time: {TimeSpan.FromSeconds(elapsed)}    Current RPS: {currentRPS:0.0}    Average RPS: {averageRPS:0.0}");
+                    Console.WriteLine($"Elapsed time: {TimeSpan.FromSeconds(elapsed/1000)}    Current RPS: {currentRPS:0.0}    Average RPS: {averageRPS:0.0}");
                 }
 
                 previousCount = currentCount;
+                previousElapsed = elapsed;
 
                 if ( options.NumberOfRequests > 0 && options.NumberOfRequests <= currentCount ) {
                     break;
                 }
-                if ( options.DurationTime > 0 && options.DurationTime <= elapsed ) {
+                if ( options.DurationTime > 0 && (options.DurationTime * 1000) <= elapsed ) {
                     break;
                 }
             }
-            if (options.ReportingInterval <= 0)
-            {
-                // write out final stats if we are asked not to do it interactively.
-                Console.WriteLine($"Elapsed time: {TimeSpan.FromSeconds(elapsed)}    Average RPS: {averageRPS:0.0}");
-            }
+            timer.Stop();
+            // write out final stats if we are asked not to do it interactively.
+            Console.WriteLine($"Total elapsed time: {timer.Elapsed}    Average RPS: {averageRPS:0.0} Total requests: {GetCurrentRequestCount(clientHandlers)}");
         }
 
         static X509Certificate2 GetX509Certificate(BaseOptions options) =>


### PR DESCRIPTION
The options are best guess - we will terminate on next iteration when condition is met. 

furt@Ubuntu:~/git/netpwerf-furt/SocketPerfTest$ ~/dotnet/dotnet run client
SocketPerfTest 1.0.0
Copyright (C) 2017 SocketPerfTest

ERROR(S):
  Required option 'e, endPoint' is missing.

  -e, --endPoint             Required.

  -c, --connections          (Default: 256)

  -w, --warmupTime           (Default: 5)

  -i, --reportingInterval    (Default: 3)

  -n, --numberOfRequests     (Default: 0) Total number of requests if positive number

  -t, --durationTime         (Default: 0) Duration of test in seconds if positive number

  -s, --messageSize          (Default: 256) Message size to send

  --ssl                      (Default: false) Use SSL

  --help                     Display this help screen.

  --version                  Display version information.


 ~/dotnet/dotnet run client -e 127.0.0.1:5000 -t 30 -i 0
Running client to 127.0.0.1:5000
Test running with 256 clients and MessageSize=256
Using raw sockets (no SSL)
Waiting 5 seconds for warmup
Warmup complete
Elapsed time: 00:00:30    Average RPS: 91443.4

I also modified the interval option so the report for each iteration can be stressed and tool would print just final number. That will make it easier for test automation in future.

I did not change, but I'm wondering about precision of the sleep(). 
Seems like we use requested time as elapsed instead of actually getting current time. 
If there is any imprecision, it will accumulate over time. 
