### PR TITLE
add drift to show changes on average RPS. 

### DIFF
--- a/SocketPerfTest/Program.cs
+++ b/SocketPerfTest/Program.cs
@@ -127,7 +127,9 @@ namespace SslStreamPerf
             int reportingInterval = options.ReportingInterval > 0 ? options.ReportingInterval :
                                         options.DurationTime > 0 ? options.DurationTime : 1;
             double currentRPS;
-            double averageRPS;
+            double averageRPS=0;
+            double previousAverageRPS = 0;
+            double drift;
 
             timer.Start();
             while (true)
@@ -139,11 +141,14 @@ namespace SslStreamPerf
                 int currentCount = GetCurrentRequestCount(clientHandlers);
 
                 currentRPS = (currentCount - previousCount) / ((elapsed - previousElapsed)/1000);
+                previousAverageRPS = averageRPS;
                 averageRPS = (currentCount - countAfterWarmup) / ((double)elapsed/1000);
+
+                drift = averageRPS - previousAverageRPS;
 
                 if (options.ReportingInterval > 0)
                 {
-                    Console.WriteLine($"Elapsed time: {TimeSpan.FromSeconds(elapsed/1000)}    Current RPS: {currentRPS:0.0}    Average RPS: {averageRPS:0.0}");
+                    Console.WriteLine($"Elapsed time: {TimeSpan.FromSeconds(elapsed/1000)}    Current RPS: {currentRPS,10:####.0}    Average RPS: {averageRPS,10:####.0} Drift: {drift/averageRPS*100,8:0.00}%");
                 }
 
                 previousCount = currentCount;


### PR DESCRIPTION
This also fixes minor alignment problem when values fluctuates around 100k
There may be some other ways but I was looking for way how to tell the average is converging. 
The "drift" is simply delta to previous average expressed as %. 
When it drops bellow certain threshold we may consider the average good. 


```
Running client to 127.0.0.1:5000
Test running with 256 clients and MessageSize=256
Using raw sockets (no SSL)
Waiting 5 seconds for warmup
Warmup complete
Elapsed time: 00:00:03    Current RPS:    88287.0    Average RPS:    88287.3 Drift:   100.00%
Elapsed time: 00:00:06    Current RPS:    90119.0    Average RPS:    89203.5 Drift:     1.03%
Elapsed time: 00:00:09    Current RPS:    98288.0    Average RPS:    92231.9 Drift:     3.28%
Elapsed time: 00:00:12    Current RPS:   105090.0    Average RPS:    95446.5 Drift:     3.37%
Elapsed time: 00:00:15    Current RPS:   105079.0    Average RPS:    97366.6 Drift:     1.97%
Elapsed time: 00:00:18    Current RPS:   105016.0    Average RPS:    98641.6 Drift:     1.29%
Elapsed time: 00:00:21    Current RPS:   108900.0    Average RPS:   100102.3 Drift:     1.46%
Elapsed time: 00:00:24    Current RPS:   108419.0    Average RPS:   101141.8 Drift:     1.03%
Elapsed time: 00:00:27    Current RPS:   100611.0    Average RPS:   101082.8 Drift:    -0.06%
Elapsed time: 00:00:30    Current RPS:   103129.0    Average RPS:   101284.1 Drift:     0.20%
Elapsed time: 00:00:33    Current RPS:   101243.0    Average RPS:   101280.4 Drift:     0.00%
```